### PR TITLE
Add basic auth routes with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@
    - /main.py: Configuração do FastAPI
    - /routes/auth.py: Endpoints de login/registro
    - /config/supabase.py: Conexão com Supabase
-3. Endpoint inicial:
-   - GET /health: Retorna {"status": "ok"}
+3. Endpoints iniciais:
+   - `GET /health`: verifica se o servidor está online.
+   - `POST /auth/register`: cria um usuário e perfil no Supabase.
+   - `POST /auth/login`: autentica o usuário e retorna o token.
 
 ## Frontend (Nuxt 3)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,20 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from config.supabase import supabase
+from routes.auth import router as auth_router
 
 app = FastAPI()
+
+# Allow requests from any origin during early development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth_router, prefix="/auth")
 
 @app.get("/health")
 async def health_check():

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from config.supabase import supabase
+
+
+router = APIRouter()
+
+
+class RegisterPayload(BaseModel):
+    email: str
+    password: str
+    name: str | None = None
+
+
+class LoginPayload(BaseModel):
+    email: str
+    password: str
+
+
+@router.post("/register")
+async def register(payload: RegisterPayload):
+    """Create a new user and profile using Supabase."""
+    try:
+        response = supabase.auth.sign_up(
+            {
+                "email": payload.email,
+                "password": payload.password,
+                "user_metadata": {"name": payload.name or payload.email},
+            }
+        )
+        profile = {
+            "user_id": response.user.id,
+            "name": payload.name or payload.email,
+            "role": "attendant",
+        }
+        supabase.table("profiles").insert(profile).execute()
+        return {"user_id": response.user.id}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/login")
+async def login(payload: LoginPayload):
+    """Authenticate user via Supabase."""
+    try:
+        session = supabase.auth.sign_in_with_password(
+            {"email": payload.email, "password": payload.password}
+        )
+        return {"access_token": session.session.access_token}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+def test_health():
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add registration and login endpoints
- enable CORS and include auth router in the app
- document new routes in README
- add a simple test for /health

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68401647269c832085480f5e36bb7fcf